### PR TITLE
Remove RKR-AEAD dependency.

### DIFF
--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -468,7 +468,7 @@ the following ciphersuites:
 The output of the OPRF Finalize() operation may be hardened using a MHF F.
 This greatly increases the cost of an offline attack upon the compromise of
 the password file at the server. Supported MHFs include Argon2 {{?I-D.irtf-cfrg-argon2}},
-scrypt {{?RFC7914}}, and PBKDF2 {{?RFC2898}}. with suitable parameter choices.
+scrypt {{?RFC7914}}, and PBKDF2 {{?RFC2898}} with suitable parameter choices.
 
 # OPAQUE Protocol {#protocol}
 

--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -913,7 +913,7 @@ Steps:
 7. auth_key = HKDF-Expand(RwdU, concat(nonce, "AuthKey"), Nk)
 8. exporter_key = HKDF-Expand(RwdU, concat(nonce, "ExporterKey", nonce), Nk)
 9. auth_data = response.pkS
-10. t' = HMAC(auth_key, concat(nonce, ct, concat(response.pkS, aad)))
+10. t' = HMAC(auth_key, concat(nonce, ct, concat(auth_data, aad)))
 11. If !CT_EQUAL(t, t'), raise DecryptionError
 12. pt = xor(ct, pseudorandom_pad)
 13. C = DeserializeCredentials(pt)

--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -917,11 +917,11 @@ application-specific additional associated data.
 13. Output C, exporter_key
 ~~~
 
+[[RFC editor: please change "RFCXXXX" to the correct number before publication.]]
+
 As in the registration phase, applications MUST authenticate pkS; secrecy of pkS is
 optional. If an application requires secrecy of pkS, this value SHOULD be omitted
 from the HMAC computation (step 9).
-
-[[RFC editor: please change "RFCXXXX" to the correct number before publication.]]
 
 ## Exporter Keys {#exporter-usage}
 


### PR DESCRIPTION
This removes the RKR-AEAD dependency in favor of a simpler OTP-like construction for credential secrecy. It also replaces redundant Extract calls on RwdU with Expand calls (RwdU is already assumed to be the output of a RO). Finally, it removes the `context` parameter from all protocol messages, punting that functionality to applications.