### PR TITLE
Fixing typo in CredentialExtension definition and updating affiliation

### DIFF
--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -20,7 +20,7 @@ author:
  -
     ins: K. Lewi
     name: Kevin Lewi
-    organization: Facebook
+    organization: Novi
     email: lewi.kevin.k@gmail.com
  -
     ins: C. A. Wood
@@ -442,7 +442,7 @@ enum {
 
 struct {
   CredentialType type;
-  CredentialData data<0..2^16-1>;
+  opaque data<0..2^16-1>;
 } CredentialExtension;
 
 struct {


### PR DESCRIPTION
I believe the type of the parameter `data` in `CredentialExtension` should be `opaque`, since there is no `CredentialData` defined anywhere.

Also updating my affiliation