### PR TITLE
Move idU to CreateCredentialResponse parameter.

### DIFF
--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -782,7 +782,9 @@ Steps:
 CreateCredentialResponse(request)
 
 Parameters:
-- idU, the identity associated with the user
+- kU, OPRF key associated with idU
+- envU, Envelope associated with idU
+- pkU, Public key associated with idU
 
 Input:
 - request, a CredentialRequest structure
@@ -792,10 +794,9 @@ Output:
 - pkU, public key of the user
 
 Steps:
-1. (kU, envU, pkU) = LookupUserRecord(idU)
-2. Z = Evaluate(kU, request.data)
-3. Create CredentialResponse response with (Z, envU)
-4. Output (response, pkU)
+1. Z = Evaluate(kU, request.data)
+2. Create CredentialResponse response with (Z, envU)
+3. Output (response, pkU)
 ~~~
 
 #### RecoverCredentials(pwdU, metadata, request, response)

--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -489,7 +489,7 @@ multiple users. These steps can happen offline, i.e., before the registration ph
 Once complete, the registration process proceeds as follows:
 
 ~~~
- Client (idU, pwdU, skU, pkU)                 Server (skS, pkS)
+      Client (pwdU, skU, pkU)                 Server (skS, pkS)
   -----------------------------------------------------------------
    request, metadata = CreateRegistrationRequest(pwdU)
 
@@ -702,7 +702,7 @@ shared secret key.
 This section describes the message flow, encoding, and helper functions used in this stage.
 
 ~~~
- Client (idU, pwdU)                           Server (skS, pkS)
+       Client (pwdU)                           Server (skS, pkS)
   -----------------------------------------------------------------
    request, metadata = CreateCredentialRequest(pwdU)
 
@@ -789,6 +789,9 @@ Steps:
 ~~~
 CreateCredentialResponse(request)
 
+Parameters:
+- idU, the identity associated with the user
+
 Input:
 - request, a CredentialRequest structure
 
@@ -797,7 +800,7 @@ Output:
 - pkU, public key of the user
 
 Steps:
-1. (kU, envU, pkU) = LookupUserRecord(request.id)
+1. (kU, envU, pkU) = LookupUserRecord(idU)
 2. M = Deserialize(request.data)
 3. Z = Evaluate(kU, M)
 4. data = Z.encode()

--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -490,7 +490,7 @@ multiple users. These steps can happen offline, i.e., before the registration ph
 Once complete, the registration process proceeds as follows:
 
 ~~~
-      Client (pwdU, skU, pkU)                 Server (skS, pkS)
+      Client (pwdU, skU, pkU)                       Server (skS, pkS)
   -----------------------------------------------------------------
    request, metadata = CreateRegistrationRequest(pwdU)
 
@@ -697,14 +697,14 @@ shared secret key.
 This section describes the message flow, encoding, and helper functions used in this stage.
 
 ~~~
-       Client (pwdU)                           Server (skS, pkS)
+       Client (pwdU)                       Server (skS, pkS, kU, envU, pkU)
   -----------------------------------------------------------------
    request, metadata = CreateCredentialRequest(pwdU)
 
                                    request
                               ----------------->
 
-                       response = CreateCredentialResponse(request)
+                response = CreateCredentialResponse(request, kU, envU, pkU)
 
                                    response
                               <-----------------
@@ -776,18 +776,16 @@ Steps:
 4. Output (request, metadata)
 ~~~
 
-#### CreateCredentialResponse(request)
+#### CreateCredentialResponse(request, kU, envU, pkU)
 
 ~~~
-CreateCredentialResponse(request)
-
-Parameters:
-- kU, OPRF key associated with idU
-- envU, Envelope associated with idU
-- pkU, Public key associated with idU
+CreateCredentialResponse(request, kU, envU, pkU)
 
 Input:
 - request, a CredentialRequest structure
+- kU, OPRF key associated with idU
+- envU, Envelope associated with idU
+- pkU, Public key associated with idU
 
 Output:
 - response, a CredentialResponse structure

--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -704,7 +704,7 @@ This section describes the message flow, encoding, and helper functions used in 
                                    request
                               ----------------->
 
-         (response, pkU) = CreateCredentialResponse(request)
+                       response = CreateCredentialResponse(request)
 
                                    response
                               <-----------------
@@ -791,12 +791,11 @@ Input:
 
 Output:
 - response, a CredentialResponse structure
-- pkU, public key of the user
 
 Steps:
 1. Z = Evaluate(kU, request.data)
 2. Create CredentialResponse response with (Z, envU)
-3. Output (response, pkU)
+3. Output response
 ~~~
 
 #### RecoverCredentials(pwdU, metadata, request, response)


### PR DESCRIPTION
The OPAQUE wrapper protocol is responsible for transmitting idU from
client to server. OPAQUE does not use it for anything other than password
file lookup.

Closes #88.

cc @kevinlewi, @stef