### PR TITLE
Changing envelope definition to  support two fixed modes

### DIFF
--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -670,7 +670,7 @@ This section describes the message flow, encoding, and helper functions used in 
                                    request
                               ----------------->
 
-                response = CreateCredentialResponse(request, kU, envU, pkU)
+                response = CreateCredentialResponse(request, pkS, kU, envU, pkU)
 
                                    response
                               <-----------------
@@ -706,12 +706,16 @@ data
 ~~~
 struct {
     opaque data<1..2^16-1>;
+    opaque pkS<1..2^16-1>;
     Envelope envelope;
 } CredentialResponse;
 ~~~
 
 data
 : A serialized OPRF group element.
+
+pkS
+: An encoded public key that will be used for the online authenticated key exchange stage.
 
 envelope
 : The `Envelope` structure.
@@ -736,13 +740,14 @@ Steps:
 3. Output (request, r)
 ~~~
 
-#### CreateCredentialResponse(request, kU, envU, pkU)
+#### CreateCredentialResponse(request, pkS, kU, envU, pkU)
 
 ~~~
-CreateCredentialResponse(request, kU, envU, pkU)
+CreateCredentialResponse(request, pkS, kU, envU, pkU)
 
 Input:
 - request, a CredentialRequest structure
+- pkS, public key of the server
 - kU, OPRF key associated with idU
 - envU, Envelope associated with idU
 - pkU, Public key associated with idU
@@ -752,7 +757,7 @@ Output:
 
 Steps:
 1. Z = Evaluate(kU, request.data)
-2. Create CredentialResponse response with (Z, envU)
+2. Create CredentialResponse response with (Z, pkS, envU)
 3. Output response
 ~~~
 


### PR DESCRIPTION
See #99.

This defines two modes, `base` and `customIdentifier` for the envelope. The credentials are incorporated in the `SecretCredentials` and `CleartextCredentials` structs,
depending on the mode set by the value of `EnvelopeMode`:

```
enum {
  base(1),
  customIdentifier(2),
  (255)
} EnvelopeMode;
```

The `base` mode defines `SecretCredentials` and `CleartextCredentials` as follows:

```
struct {
  opaque skU<1..2^16-1>;
} SecretCredentials;

struct {
  opaque pkS<1..2^16-1>;
} CleartextCredentials;
```

The `customIdentifier` mode defines `SecretCredentials` and `CleartextCredentials` as follows:

```
struct {
  opaque skU<1..2^16-1>;
} SecretCredentials;

struct {
  opaque pkS<1..2^16-1>;
  opaque idU<0..2^16-1>;
  opaque idS<0..2^16-1>;
} CleartextCredentials;
```

These credentials are embedded into the following `Envelope` structure with
encryption and authentication.

```
struct {
  InnerEnvelopeMode mode;
  opaque nonce[32];
  opaque ct<1..2^16-1>;
} InnerEnvelope;

struct {
  InnerEnvelope contents;
  opaque auth_tag[Nh];
} Envelope;
```

Also updated the `FinalizeRequest` and `RecoverCredentials` procedures accordingly. Also updated the fixed string to read `OPAQUE01` instead of `OPAQUE00`.