### PR TITLE
Pin envelope mode to base or customIdentifier.

### DIFF
--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -357,12 +357,6 @@ OPAQUE relies on the following protocols and primitives:
   - Unblind(r, Z): Remove random Scalar `r` from `Z`, yielding output `N`.
   - Finalize(x, N, info): Compute the OPRF output using input `x`, `N`, and domain
     separation tag `info`.
-  - Serialize(x): Encode the OPRF group element x as a fixed-length byte string
-    `enc`. The size of `enc` is determined by the underlying OPRF group. The type
-    of a serialized OPRF group element is called SerializedElement.
-  - Deserialize(enc): Decode a byte string `enc` into an OPRF group element `x`,
-    or produce an error if `enc` is an invalid encoding. This is the inverse
-    of Serialize, i.e., `x = Deserialize(Serialize(x))`.
 
 - Cryptographic hash function:
   - Hash(m): Compute the cryptographic hash of input message `m`. The type of the

--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -469,6 +469,9 @@ struct {
 } Envelope;
 ~~~
 
+mode
+: The `EnvelopeMode` value. This MUST be one of `base` or `customIdentifier`.
+
 nonce
 : A unique 32-byte nonce used to protect this Envelope.
 
@@ -547,7 +550,7 @@ data
 ~~~
 struct {
     SerializedElement data;
-    opaque pkS<0..2^16-1>;
+    opaque pkS<1..2^16-1>;
 } RegistrationResponse;
 ~~~
 
@@ -560,7 +563,7 @@ pkS
 ~~~
 struct {
     Envelope envU;
-    opaque pkU<0..2^16-1>;
+    opaque pkU<1..2^16-1>;
 } RegistrationUpload;
 ~~~
 
@@ -1170,7 +1173,8 @@ The OPAQUE AKE protocols are those which are specified in {{instantiations}}.
 Future specifications (such as {{I-D.sullivan-tls-opaque}}) MAY introduce other
 AKE instantiations.
 
-The EnvelopeMode value is defined in {{data-types}}.
+The EnvelopeMode value is defined in {{data-types}}. It MUST be one of `base`
+or `customIdentifier`.
 
 [[https://github.com/cfrg/draft-irtf-cfrg-opaque/issues/60: Should we have a registry for configurations?]]
 
@@ -1245,7 +1249,7 @@ authenticated-encryption scheme with this specification. (Deviating from the
 key-robustness requirement may open the protocol to attacks, e.g., {{LGR20}}.)
 We remark that export_key for authentication or encryption requires no special
 properties from the authentication or encryption schemes as long as export_key
-is used only after the EnvU is validated, i.e., after the HMAC in RecoverCredentials
+is used only after the envU is validated, i.e., after the HMAC in RecoverCredentials
 passes verification.
 
 ## Configuration choice


### PR DESCRIPTION
I chose to leave the enumeration and restrict its values to in the text. 

As discussed, this also makes pkU/pkS mandatory in the core OPAQUE messages.