### PR TITLE
Surround multiple output params with parentheses in process diagrams.

### DIFF
--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -516,19 +516,19 @@ multiple users. These steps can happen offline, i.e., before the registration ph
 Once complete, the registration process proceeds as follows:
 
 ~~~
-  Client (pwdU, creds)                             Server (skS, pkS)
-  ------------------------------------------------------------------
-  request, blind = CreateRegistrationRequest(pwdU)
+ Client (pwdU, creds)                               Server (skS, pkS)
+ --------------------------------------------------------------------
+ (request, blind) = CreateRegistrationRequest(pwdU)
 
                                request
                       ------------------------->
 
-             response, kU = CreateRegistrationResponse(request, pkS)
+            (response, kU) = CreateRegistrationResponse(request, pkS)
 
                                response
                       <-------------------------
 
-  record, export_key = FinalizeRequest(pwdU, creds, blind, response)
+ (record, export_key) = FinalizeRequest(pwdU, creds, blind, response)
 
                                 record
                       ------------------------->
@@ -692,19 +692,19 @@ shared secret key.
 This section describes the message flow, encoding, and helper functions used in this stage.
 
 ~~~
-  Client (pwdU)                    Server (skS, pkS, credentialFile)
-  ------------------------------------------------------------------
-  request, blind = CreateCredentialRequest(pwdU)
+ Client (pwdU)                      Server (skS, pkS, credentialFile)
+ --------------------------------------------------------------------
+ (request, blind) = CreateCredentialRequest(pwdU)
 
                                request
                       ------------------------->
 
-   response = CreateCredentialResponse(request, pkS, credentialFile)
+    response = CreateCredentialResponse(request, pkS, credentialFile)
 
                                response
                       <-------------------------
 
-  skU, pkS, export_key = RecoverCredentials(pwdU, blind, response)
+ (skU, pkS, export_key) = RecoverCredentials(pwdU, blind, response)
 
                         (AKE with credentials)
                       <========================>


### PR DESCRIPTION
In the steps for functions, we surround multiple output params with
parentheses:
```
Steps:
1. (blind, M) = Blind(pwdU)
2. Create RegistrationRequest request with M
3. Output (request, blind)
```

@crockeea pointed out that we should be consistent. From
https://github.com/cfrg/draft-irtf-cfrg-opaque/issues/112#issuecomment-760522234,
"Be consistent about the use of parens for functions which output multiple
values (see protocol diagrams at top of section 3.2 and at the top of 3.3)".