### PR TITLE
Update the keyagreement reference

### DIFF
--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -123,7 +123,7 @@ key exchange resilient to server compromise"
   I-D.irtf-cfrg-voprf:
   I-D.sullivan-tls-opaque:
 
-  keyagreement: DOI.10.6028/NIST.SP.800-56Ar3
+  keyagreement: NIST.NIST.SP.800-56Ar3
 
   OPAQUE:
     title: "OPAQUE: An Asymmetric PAKE Protocol Secure Against Pre-Computation


### PR DESCRIPTION
so that the "Update Editor's Copy" GitHub action succeeds.

The GitHub action fails with the following message:
```
/github/home/.cache/xml2rfc/reference.DOI.10.6028_NIST.SP.800-56Ar3--anchor=keyagreement.xml: fetching
*** 404 NOT FOUND while fetching https://xml2rfc.tools.ietf.org/public/rfc/bibxml7/reference.DOI.10.6028/NIST.SP.800-56Ar3.xml?anchor=keyagreement
*** No such file or directory @ rb_sysopen - /github/home/.cache/xml2rfc/reference.DOI.10.6028_NIST.SP.800-56Ar3--anchor=keyagreement.xml for /github/home/.cache/xml2rfc/reference.DOI.10.6028_NIST.SP.800-56Ar3--anchor=keyagreement.xml
Error: Unable to parse the XML document: /dev/stdin
make: *** [lib/main.mk:68: draft-irtf-cfrg-opaque.xml] Error 1
```
See https://github.com/cfrg/draft-irtf-cfrg-opaque/runs/1797781503 .

There is an alternate link to this reference here:
https://xml2rfc.tools.ietf.org/public/rfc/bibxml-nist/reference.NIST.NIST.SP.800-56Ar3.xml .