### PR TITLE
Addressing comments from issue #124

### DIFF
--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -327,17 +327,16 @@ operations, roles, and behaviors of OPAQUE:
 - Client (C): Entity which has knowledge of a password and wishes to authenticate.
 - Server (S): Entity which authenticates clients using passwords.
 - password: An opaque byte string containing the client's password.
-- (skX, pkX): An AKE key pair used in role X; skX is the private key and pkX is
-  the public key. For example, (client_private_key, client_public_key) refers to C's private and public key.
-- kX: An OPRF private key used for role X. For example, as described in
-  {{create-reg-response}}, oprf_key refers to the private OPRF key for client C known
-  only to the server.
+- (client/server_private_key, client/server_public_key): An AKE key pair used by
+  either the client and server, denoting either the private or public key. For example,
+  (client_private_key, client_public_key) refers to C's private and public key.
+- oprf_key: An OPRF private key known only to the server.
 - I2OSP and OS2IP: Convert a byte string to and from a non-negative integer as
-  described in {{?RFC8017}}. Note that these functions operate on byte strings in
+  described in Section 4 of {{?RFC8017}}. Note that these functions operate on byte strings in
   big-endian byte order.
 - concat(x0, ..., xN): Concatenate byte strings. For example,
   `concat(0x01, 0x0203, 0x040506) = 0x010203040506`.
-- random(n): Generate a random byte string of length `n` bytes.
+- random(n): Generate a cryptographically secure pseudorandom byte string of length `n` bytes.
 - xor(a,b): Apply XOR to byte strings. For example, `xor(0xF0F0, 0x1234) = 0xE2C4`.
   It is an error to call this function with two arguments of unequal
   length.
@@ -376,7 +375,10 @@ OPAQUE relies on the following protocols and primitives:
     the input is not a valid byte representation of a scalar.
   - SerializedElement: A serialized OPRF group element, a byte array of fixed
     length.
-  - SerializedScalar: A serialized OPRF scalar, a byte array of fixed length.
+  - SerializedScalar: A serialized OPRF scalar, a byte array of fixed length.\
+
+Note that we only need the base mode variant (as opposed to the verifiable mode
+variant) of the OPRF described in {{I-D.irtf-cfrg-voprf}}.
 
 - Cryptographic hash function:
   - Hash(m): Compute the cryptographic hash of input message `m`. The type of the
@@ -388,8 +390,6 @@ OPAQUE relies on the following protocols and primitives:
     `params` to strengthen the input `msg` against offline dictionary attacks.
     This function also needs to satisfy collision resistance.
 
-Note that we only need the base mode variant (as opposed to the verifiable mode
-variant) of the OPRF described in {{I-D.irtf-cfrg-voprf}}.
 
 # Offline Registration {#offline-phase}
 
@@ -525,7 +525,7 @@ The `EnvelopeMode` value is specified as part of the configuration (see {{config
 
 Credential information corresponding to the configuration-specific mode,
 along with the client public key `client_public_key` and private key `client_private_key`,
-are stored in a `Credentials` object with the following named fields:
+are recommended to be stored in a `Credentials` object with the following named fields:
 
 - `client_private_key`, the client's private key
 - `client_public_key`, the client's public key corresponding to `client_private_key`
@@ -554,7 +554,7 @@ data
 : A serialized OPRF group element.
 
 server_public_key
-: An encoded public key that will be used for the online authenticated key exchange stage.
+: The server's encoded public key that will be used for the online authenticated key exchange stage.
 
 ~~~
 struct {
@@ -564,7 +564,7 @@ struct {
 ~~~
 
 client_public_key
-: An encoded public key, corresponding to the private key `client_private_key`.
+: The client's encoded public key, corresponding to the private key `client_private_key`.
 
 envelope
 : The client's `Envelope` structure.
@@ -662,7 +662,8 @@ Upon completion of this function, the client MUST send `record` to the server.
 
 The server then constructs and stores the `credential_file` object, where `envelope` and `client_public_key`
 are obtained from `record`, and `oprf_key` is retained from the output of `CreateRegistrationResponse`.
-`oprf_key` is serialized using `SerializeScalar`.
+`oprf_key` is serialized using `SerializeScalar`. The below structure represents an example of how
+these values might be conveniently stored together.
 
 ~~~
 struct {
@@ -738,7 +739,7 @@ data
 : A serialized OPRF group element.
 
 server_public_key
-: An encoded public key that will be used for the online authenticated
+: The server's encoded public key that will be used for the online authenticated
 key exchange stage.
 
 envelope
@@ -1326,7 +1327,7 @@ The OPAQUE protocol and its analysis is joint work of the author with Stas
 Jarecki and Jiayu Xu. We are indebted to the OPAQUE reviewers during CFRG's
 aPAKE selection process, particularly Julia Hesse and Bjorn Tackmann.
 This draft has benefited from comments by multiple people. Special thanks
-to Richard Barnes, Dan Brown, Eric Crockett, Paul Grubbs, Fredrik oprf_keyivinen,
+to Richard Barnes, Dan Brown, Eric Crockett, Paul Grubbs, Fredrik Kuivinen,
 Payman Mohassel, Jason Resch, Greg Rubin, and Nick Sullivan.
 
 # Alternate AKE Instantiations {#alternate-akes}
@@ -1645,4 +1646,3 @@ KE1: 7024ca0d5423176294fbb9ca968d8ce3fc879a231f1ceef69e672c89e02ded59
 8656c6c6f20626f624ae7d50bb80cc8f5034d36c1c27edc30caca0983677a941bc0ac
 e5e10b18300a
 ~~~
-


### PR DESCRIPTION
@stef, replying to your suggestions in-line below. Please let me know if these adequately address the concerns you brought up! Closes #124 

> > 2OSP and OS2IP: Convert a byte string to and from a non-negative integer as described in {{?RFC8017}}.
> 
> link to https://tools.ietf.org/html/rfc8017#section-4.1 and https://tools.ietf.org/html/rfc8017#section-4.2
> 
> perhaps also note that this is also known as the htons/ntohs functions in POSIX - implementors might find this very helpful!

Added a mention that these can be found in Section 4, but did not add the POSIX references since I could not find a link to them, and these may not be as widely known.

> 
> > kX: An OPRF private key used in role X. For example, kU refers to U's private OPRF key.
> 
> is there any other role besides kU?

Good point, changed the text to refer to `oprf_key` instead of `kU`.

> 
> > random(n): Generate a random byte string of length n bytes.
> 
> note that this random string should be of cryptographic quality. although there is a note under all the definitions saying so, it's better to have it closer where it matters and less ignored.

Added a note here that it should be cryptographically-secure

> 
> in #cryptographic-protocol-and-algorithm-dependencies-dependencies
> 
> the note that only the base variant of the OPRF is needed is also a bit far away from where the OPRF dependency is specified.

Shifted the sentence to be right under the OPRF text

> 
> > auth_tag : Authentication tag protecting the contents of the envelope, covering InnerEnvelope and CleartextCredentials
> 
> then it notes:
> 
> > The full procedure for constructing Envelope and InnerEnvelope from SecretCredentials and CleartextCredentials is described in {{finalize-request}}.
> 
> which is:
> 
> > 1. auth_tag = HMAC(auth_key, concat(contents, cleartext_creds))
> 
> it's all there but quite dispersed spatially, someone trying to implement this has to jump around in the doc, it's very hard to read this spec sequentially.

Unfortunately I could not find a way to address this without a major rework to the organization of the doc, since I think it is somewhat inherent to how it is currently laid out.

> 
> > Credential information corresponding to the configuration-specific mode, along with the user public key pkU and private key skU, are stored in a Credentials object with the following named fields:
> > skU, pkU, idU, idS
> 
> it is not necessary to specify for interoperability how an implementation stores these values. also for security i think it is better to handle skU seperatately from the other values - or maybe not, depending on the configuration, if any of the other values is also to be kept secret. a sensible implementation wants to actually protect the sensitive values differently from the public values. maybe by storing them in mprotected/sanitized-after-use storage, in secure elements, or something else.
> 
> i do see how it is a shortcut to list all the necessary items from the creds struture as an input to finalizerequest though.

Added text saying that this is "recommended", to emphasize the point that it is not required

> 
> > Clients MUST NOT use the same key pair (skU, pkU) for two different accounts.
> 
> why is this, when the server can use the same keypair for different accounts? in the case when idU == pkU this is not even possible i guess.

Right, well if multiple accounts have the same skU associated with them, then decrypting one envelope would result in yielding the same secret for another without having to know the other account's password -- presumably this is bad for security.

> 
> > pkS : An encoded public key that will be used for the online authenticated key exchange stage.
> 
> add explicitly that this is the _servers_ pubkey
> 
> similarly be explicit also about this:
> 
> > pkU : An encoded public key, corresponding to the private key skU.
> 

Added, thanks!

> #credential-file
> 
> we agree these things need to be persisted, however i do not see how this helps interoperability or security specifying this struct. i propose to change the wording to something like:
> 
> the server needs to be able to reproduce the following values for the online phase.
> 
> an implementation might choose to generate kU by doing a KDF on some global secret value in combination with idU for example, then this storage of kU can be skipped. again we should realize that kU is a sensitive value which needs protection (like sanitization, possibly also at-rest encryption, not being swapped to disk, stored in a secure element, etc) while envU is an encrypted blob that does not need these kind of protections. in case pkU == idU it might be possbile that envU is stored in a hashdictionary that is indexed by idU, and thus pkU does not need to be stored at all. lumping these values together and requiring them to be stored in this structure creates unnecessary limitations on implementations. while this specification might harm security, it does not really improve interoperability.
> 
> either delete this section, or make this optional, and put it into an non-binding appendix.
> 
> another thing against this, is the usage of export-keys, in case an implementation chooses to encrypt data with an export-key but wants to stay stateless on the client, then the export-key encrypted data might also be stored on the server.

Added text to emphasize that this is not a requirement of the spec: "The below structure represents an example of how
these values might be conveniently stored together."