### PR TITLE
New Envelope mode proposal including private key derivation from OPRF output

### DIFF
--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -602,7 +602,7 @@ Output:
 - client_public_key, the client's AKE public key
 
 Steps:
-1. seed = Expand(prk, concat(nonce, "PrivateKey"), Nh)
+1. seed = Expand(prk, concat(nonce, "PrivateKey"), Nsk)
 2. _, client_public_key = DeriveAkeKeyPair(seed)
 3. Output (nil, client_public_key)
 ~~~

--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -493,7 +493,7 @@ Parameter:
 Input:
 - prk, pseudo-random key
 - server_public_key, The encoded server public key for the AKE protocol
-- client_private_key, The encoded client private key for the AKE protocol
+- client_private_key, The encoded client private key for the AKE protocol. This is nil in the internal key mode
 - server_identity, The encoded server identity
 - client_identity, The encoded client identity
 
@@ -817,7 +817,7 @@ Steps:
 FinalizeRequest(client_private_key, password, blind, response)
 
 Input:
-- client_private_key, the client's private key. In the internal key mode, this is empty.
+- client_private_key, the client's private key. In the internal key mode, this is nil
 - password, an opaque byte string containing the client's password
 - creds, a Credentials structure
 - blind, the OPRF scalar value used for blinding

--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -484,6 +484,9 @@ The size of the serialized envelope is denoted `Ne` and varies based on the mode
 
 The `CreateEnvelope` function allows a client to create its `Envelope` at registration.
 
+For the `external` key mode, implementations are free to addtionnally provide the `client_public_key` to this function. With this the the public key doesn't have to be recovered in BuildInnerEnvelope() (thus saving a scalar multiplication) and that function must then be adapted accordingly.
+For the `internal` key mode, implementations can chose to leave the `client_private_key` out completely, as it is not used.
+
 ~~~
 CreateEnvelope(prk, server_public_key, client_private_key, creds)
 
@@ -638,6 +641,8 @@ struct {
 ~~~
 
 encrypted_creds : Encrypted client_private_key. Authentication of this field is ensured with the `AuthTag` in the envelope that covers this `InnerEnvelope`.
+
+If the implementation provides the `client_public_key` to `CreateEnvelope()`, then `BuildInnerEnvelope()` should spare the `RecoverPublicKey()` call as the key is already available.
 
 ~~~
 BuildInnerEnvelope(prk, nonce, client_private_key)
@@ -812,6 +817,11 @@ Steps:
 ~~~
 
 ### FinalizeRequest {#finalize-request}
+
+To create the user record used for further authentication, the client executes the following function. In the internal key mode, the `client_private_key` is empty or nil.
+
+For the `external` key mode, implementations are free to addtionnally provide the `client_public_key` to this function. With this the the public key doesn't have to be recovered in BuildInnerEnvelope() (thus saving a scalar multiplication) and that function must then be adapted accordingly.
+For the `internal` key mode, implementations can chose to leave the `client_private_key` out completely, as it is not used.
 
 ~~~
 FinalizeRequest(client_private_key, password, blind, response)


### PR DESCRIPTION
After discussions with @chris-wood and @kevinlewi and the thread in #84, this PR is a first sketch of a proposal to address these discussions.

Proposal of new envelope modes

1. **Drop Base/CustomIdentifiers**
CleartextCredentials always contain pks, idu and ids. If not supplied by the client, idu and ids MUST default to the public keys.
2. Introduce two new modes
    a. **Internal mode**
    The client keys are generated internally from a seed. (also called "seed mode", "encryption-less mode", etc. in different issues and conversations). No encrypted creds in the envelope. Applications are not expected to know how to deal with key generation.
    b. **External mode**
    The client keys are provided by the application, and OPAQUE encrypts the private key into the encrypted creds in the envelope.

Isolating the Envelope description and mode, as well as the rearrangements, are my own suggestions and not part of the discussions.