### PR TITLE
Consistent format for OPRF group elements

### DIFF
--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -347,9 +347,7 @@ OPAQUE relies on the following protocols and primitives:
   - Finalize(x, r, Z): Finalize the OPRF evaluation using input `x`,
     random scalar `r`, and evaluation output `Z`, yielding output `y`.
   - DeriveKeyPair(seed): Derive a private and public key pair deterministically from a seed.
-  - SerializedElement: A serialized OPRF group element, a byte array of fixed
-    length.
-  - SerializedScalar: A serialized OPRF scalar, a byte array of fixed length.
+  - Noe: The size of a serialized OPRF group element.
   - Nok: The size of an OPRF private key.
 
 Note that we only need the base mode variant (as opposed to the verifiable mode
@@ -766,7 +764,7 @@ Upon completion, S stores C's credentials for later use.
 
 ~~~
 struct {
-    SerializedElement data;
+    opaque data[Noe];
 } RegistrationRequest;
 ~~~
 
@@ -775,7 +773,7 @@ data
 
 ~~~
 struct {
-    SerializedElement data;
+    opaque data[Noe];
     opaque server_public_key[Npk];
 } RegistrationResponse;
 ~~~
@@ -933,7 +931,7 @@ more detail.
 
 ~~~
 struct {
-    SerializedElement data;
+    opaque data[Noe];
 } CredentialRequest;
 ~~~
 
@@ -942,7 +940,7 @@ data
 
 ~~~
 struct {
-    SerializedElement data;
+    opaque data[Noe];
     opaque masking_nonce[Nn];
     opaque masked_response[Npk + Ne];
 } CredentialResponse;


### PR DESCRIPTION
- introduce Noe, the serialized element length in the OPRF group
- deleted mention of SerializedScalar, since it's not used
- deleted mention of SerializedElement, since it's not used
- specify OPRF group element lengths in message structures

Closes #179 