### PR TITLE
Contradictory statements on draft

### DIFF
--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -472,14 +472,13 @@ obtain its authentication material.
 OPAQUE allows applications to either provide custom client private and public keys
 for authentication, or to generate them internally. Each public and private key
 value is encoded as a byte string, specific to the AKE protocol in which OPAQUE
-is instantiated. These two options are defined as the `internal` and `external`
+is instantiated. These two options are defined as the `external` and `internal`
 modes, respectively. See {{envelope-modes}} for their specifications.
 
 Applications may pin key material to identities if desired. If no identity is given
 for a party, its value MUST default to its public key. The following types of
 application credential information are considered:
 
-- client_private_key: The encoded client private key for the AKE protocol.
 - client_public_key: The encoded client public key for the AKE protocol.
 - server_public_key: The encoded server public key for the AKE protocol.
 - client_identity: The client identity. This is an application-specific value,

--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -479,6 +479,7 @@ Applications may pin key material to identities if desired. If no identity is gi
 for a party, its value MUST default to its public key. The following types of
 application credential information are considered:
 
+- client_private_key: The encoded client private key for the AKE protocol.
 - client_public_key: The encoded client public key for the AKE protocol.
 - server_public_key: The encoded server public key for the AKE protocol.
 - client_identity: The client identity. This is an application-specific value,


### PR DESCRIPTION
I've been studying OPAQUE for the last month or so (and I must say I'm in love with it). Yesterday I was reading the draft and found two statements that looked a little contradictory. 

I sent an email asking if one of them was really an accident and @bytemare (at least I think it was him lol) replied me saying that I was correct and also that you guys were accepting pull requests, so here I am :blush:.

- The first statement is the one that that I sent on the email: this statement at the fourth section, second paragraph:  "OPAQUE allows applications to either provide custom client private and public keys for authentication, or to generate them internally. [...] These two options are defined as the "internal" and "external" modes, respectively. [...]"... I think that "internal mode" would better refer to "generate keys internally", so the "respectively" term was kinda misleading.
- The second statement is at the fourth section, third paragraph: "The following types of application credential information are considered: client_private_key: The encoded client private key for the AKE protocol." Every other item on this list was indeed used and stored inside the `CleartextCredentials` struct, but client_private_key was totally ignored, so I guess it's actually not a credential information to be considered (at least at this context).

I don't know if any of what I said really makes sense to you guys, but I hope it does help ✌🏻 .