### PR TITLE
set state.ke1 in client Start, removed unused ke1 input

### DIFF
--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -1433,7 +1433,7 @@ Steps:
 ~~~
 
 ~~~
-ClientFinish(client_identity, password, server_identity, ke1, ke2)
+ClientFinish(client_identity, password, server_identity, ke2)
 
 State:
 - state, a ClientState structure
@@ -1444,7 +1444,6 @@ Input:
 - password, an opaque byte string containing the client's password.
 - server_identity, the optional encoded server identity, which is set
   to server_public_key if not specified.
-- ke1, a KE1 message structure.
 - ke2, a KE2 message structure.
 
 Output:
@@ -1457,7 +1456,7 @@ Steps:
                        server_identity, client_identity)
 2. (ke3, session_key) =
     ClientFinalize(client_identity, client_private_key, server_identity,
-                    server_public_key, ke1, ke2)
+                    server_public_key, ke2)
 3. Output (ke3, session_key)
 ~~~
 
@@ -1483,12 +1482,13 @@ Steps:
 2. client_secret, client_keyshare = GenerateAuthKeyPair()
 3. Create KE1 ke1 with (credential_request, client_nonce, client_keyshare)
 4. state.client_secret = client_secret
-5. Output (ke1, client_secret)
+5. state.ke1 = ke1
+6. Output (ke1, client_secret)
 ~~~
 
 ~~~
 ClientFinalize(client_identity, client_private_key, server_identity,
-               server_public_key, ke1, ke2)
+               server_public_key, ke2)
 
 State:
 - state, a ClientState structure.


### PR DESCRIPTION
Hi, found this while implementing the protocol. You can always set the value outside, but I think adding this step `state.ke1 = ke1` inside `Start` is very convenient and aligned with the use of `state.ke1` inside `ClientFinalize`.