### PR TITLE
Comment about client-side hardening in security considerations

### DIFF
--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -1744,7 +1744,11 @@ not the point at infinity.
 
 Hardening the output of the OPRF greatly increases the cost of an offline
 attack upon the compromise of the credential file at the server. Applications
-SHOULD select parameters that balance cost and complexity.
+SHOULD select parameters that balance cost and complexity. Note that in
+OPAQUE, the hardening function is executed by the client, as opposed to
+the server. This means that applications must consider a tradeoff between the
+performance of the protocol on clients (specifically low-end devices) and
+protection against offline attacks after a server compromise.
 
 ## Client Enumeration {#preventing-client-enumeration}
 
@@ -1834,16 +1838,16 @@ Payman Mohassel, Jason Resch, Greg Rubin, and Nick Sullivan.
 # Alternate Key Recovery Mechanisms {#alternate-key-recovery}
 
 Client authentication material can be stored and retrieved using different key
-recovery mechanisms, provided these mechanisms adhere to the requirements 
+recovery mechanisms, provided these mechanisms adhere to the requirements
 specified in {{deps-keyrec}}. Any key recovery mechanism that encrypts data
 in the envelope MUST use an authenticated encryption scheme with random
-key-robustness (or key-committing). Deviating from the key-robustness 
+key-robustness (or key-committing). Deviating from the key-robustness
 requirement may open the protocol to attacks, e.g., {{LGR20}}.
-This specification enforces this property by using a MAC over the envelope 
-contents. 
+This specification enforces this property by using a MAC over the envelope
+contents.
 
-We remark that export_key for authentication or encryption requires 
-no special properties from the authentication or encryption schemes 
+We remark that export_key for authentication or encryption requires
+no special properties from the authentication or encryption schemes
 as long as export_key is used only after authentication material is successfully
 recovered, i.e., after the MAC in RecoverCredentials passes verification.
 


### PR DESCRIPTION
New text added to the OPRF hardening sub-section of the Security Considerations section, see below:

Hardening the output of the OPRF greatly increases the cost of an offline
attack upon the compromise of the credential file at the server. Applications
SHOULD select parameters that balance cost and complexity. Note that in
OPAQUE, the hardening function is executed by the client, as opposed to
the server. This means that applications must consider a tradeoff between the
performance of the protocol on clients (specifically low-end devices) and
protection against offline attacks after a server compromise.

Closes #239 