### PR TITLE
Expose export key after generating ke3

### DIFF
--- a/poc/opaque_ake.sage
+++ b/poc/opaque_ake.sage
@@ -239,6 +239,7 @@ class OPAQUE3DH(KeyExchange):
         self.server_mac_key = server_mac_key
         self.client_mac_key = client_mac_key
         self.handshake_secret = handshake_secret
+        self.export_key = export_key
 
         # transcript3 == transcript2, plus server_mac
         hasher.update(server_mac)


### PR DESCRIPTION
The client is meant to get an export key (in addition to the session key) from the registration flow but `generate_ke3` ignores the export key obtained by calling `core.recover_credentials` so it can't be retrieved. I save it to the instance so it can be retrieved in the same way as the session key.