### PR TITLE
`core.finalize_request` shouldn't require `Credentials` instance

### DIFF
--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -894,7 +894,7 @@ Input:
 - blind, an OPRF scalar value.
 - response, a RegistrationResponse structure.
 - server_identity, the optional encoded server identity.
-- client_identity, the encoded client identity.
+- client_identity, the optional encoded client identity.
 
 Output:
 - record, a RegistrationRecord structure.


### PR DESCRIPTION
`core.finalize_request` requires a `Credentials` instance which it passes to `core.create_envelope` which uses `idS` and `idU` from it to create `CleartextCredentials`. However, a new client key pair is generated in `core.create_envelope` and used instead of the key pair in the `Credentials` instance.

This makes for rather confusing code where you need to generate a client key pair to create a `Credentials` instance to call `core.finalize_request`, but this is ignored and the record returned contains a different public key.

This was examplified in the `run_test_vector` method in `test_opaque_ake.sage` where on lines 158-160 (now lines 144-146), the public key generated earlier is overwritten with a different one. I have now simplified this test file.

This also brings the proof-of-concept in line with the document which only describes needing the client and server identity:

- `create_envelope`: https://www.ietf.org/archive/id/draft-irtf-cfrg-opaque-07.html#name-envelope-creation
- `finalize_request`: https://www.ietf.org/archive/id/draft-irtf-cfrg-opaque-07.html#name-finalizerequest

Of course, the client and server identity can be `None` meaning the public keys are used instead (the server public key obtained from the response and the client public key generated in `core.create_envelope`).