### PR TITLE
Match `generate_ke1` and `generate_ke3` API to document

### DIFF
--- a/poc/test_opaque_ake.sage
+++ b/poc/test_opaque_ake.sage
@@ -170,17 +170,17 @@ def run_test_vector(params):
     client_kex = OPAQUE3DH(config)
     server_kex = OPAQUE3DH(config)
 
-    ke1 = client_kex.generate_ke1(pwdU, idU, fake_pkU if is_fake else pkU, idS, pkS)
+    ke1 = client_kex.generate_ke1(pwdU)
     ke2 = server_kex.generate_ke2(ke1, oprf_seed, credential_identifier, record.envU, record.masking_key, idS, skS, pkS, idU, fake_pkU if is_fake else pkU)
     if is_fake:
         try:
-            ke3 = client_kex.generate_ke3(ke2)
+            ke3 = client_kex.generate_ke3(ke2, idU, fake_pkU, idS)
             assert False
         except:
             # Expected since the MAC was generated using garbage
             pass
     else:
-        ke3 = client_kex.generate_ke3(ke2)
+        ke3 = client_kex.generate_ke3(ke2, idU, pkU, idS)
         server_session_key = server_kex.finish(ke3)
         assert server_session_key == client_kex.session_key
 


### PR DESCRIPTION
With client transcript creation split between `generate_ke1` and `generate_ke3`, extra arguments like `idU`, and `pkU` are required for `generate_ke1`. However, if done entirely in `generate_ke3` then they are only required for `generate_ke3`.

This brings the function arguments in line with the pseudocode in the document. Also, in the document, transcript (preamble) creation is done entirely in `ClientFinalize`: https://www.ietf.org/archive/id/draft-irtf-cfrg-opaque-07.html#name-3dh-client-functions

Also, this way `pkS` is not required for `generate_ke1` or `generate_ke3` since it is obtained from `core.recover_credentials` in `generate_ke3`.

I can't think of a reason why the transcript creation needs to be split across the functions, but please let me know if there is. I hope you don't mind me submitting these pull requests! I've been trying to write a toy OPAQUE client extending this, but coudn't work out how to get `pkS` to give to `generate_ke1` without sending it separately to all the messages described in the document - after this change, I won't need it.