### PR TITLE
added libopaque to implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This requires that you have the necessary software installed.  See
 | [**Reference**](https://github.com/cfrg/draft-irtf-cfrg-opaque/tree/master/poc) | Sage     | main    | Sage         |
 | [opaque-ke](https://github.com/novifinancial/opaque-ke)                         | Rust     | main    | N/A          |
 | [opaque](https://github.com/bytemare/opaque/)                                   | Go       | main    | N/A          |
+| [libopaque](https://github.com/stef/libopaque)                                  | C        | main    | N/A          |
 | [ecc](https://github.com/aldenml/ecc)                                           | C        | main    | N/A          |
 
 ## Contributing


### PR DESCRIPTION
conforms to testvectors before the voprf09 update. proof:
https://github.com/stef/libopaque/blob/master/src/tests/opaque-testvectors.c

has one deviation, did not implement the voprf evaluate function in anticipation of it going back to the original oprf variant. hence the output for that is hardcoded, but will be removed with the vporf09 update.