### PR TITLE
Auth ClientFinalize prototype should return export_key

### DIFF
--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -1008,7 +1008,7 @@ def ClientFinish(client_identity, server_identity, ke2):
   (ke3, session_key) =
     ClientFinalize(client_identity, client_private_key, server_identity,
                     server_public_key, ke2)
-  return (ke3, session_key)
+  return (ke3, session_key, export_key)
 ~~~
 
 ## Server Authentication Functions {#opaque-server}


### PR DESCRIPTION
Update pseudocode prototype for function ClientFinalize to match the rest of the document which has it return the `export_key`