### PR TITLE
Reordering AKE subsections

### DIFF
--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -1034,7 +1034,7 @@ in the protocol. Note that this section relies on definitions of subroutines def
 in later sections:
 - `CreateCredentialRequest`, `CreateCredentialResponse`, `RecoverCredentials`
   defined in {{cred-retrieval}}
-- `AuthStart`, `AuthRespond`, `AuthClientFinalize`, and `AuthServerFinalize`
+- `AuthClientStart`, `AuthServerRespond`, `AuthClientFinalize`, and `AuthServerFinalize`
   defined in {{ake-client}} and {{ake-server}}
 
 ### ClientInit
@@ -1054,7 +1054,7 @@ Output:
 def ClientInit(password):
   request, blind = CreateCredentialRequest(password)
   state.blind = blind
-  ake_1 = AuthStart(request)
+  ake_1 = AuthClientStart(request)
   return KE1(request, ake_1)
 ~~~
 
@@ -1081,7 +1081,7 @@ def ServerInit(server_identity, server_private_key, server_public_key,
                record, credential_identifier, oprf_seed, ke1, client_identity):
   response = CreateCredentialResponse(ke1.request, server_public_key, record,
     credential_identifier, oprf_seed)
-  ake_2 = AuthRespond(server_identity, server_private_key,
+  ake_2 = AuthServerRespond(server_identity, server_private_key,
     client_identity, record.client_public_key, ke1, response)
   return KE2(response, ake_2)
 ~~~
@@ -1426,7 +1426,7 @@ def DeriveKeys(ikm, preamble):
 ### 3DH Client Functions {#ake-client}
 
 ~~~
-AuthStart
+AuthClientStart
 
 Parameters:
 - Nn, the nonce length.
@@ -1440,7 +1440,7 @@ Input:
 Output:
 - ke1, a KE1 structure.
 
-def AuthStart(credential_request):
+def AuthClientStart(credential_request):
   client_nonce = random(Nn)
   (client_secret, client_keyshare) = GenerateAuthKeyPair()
   Create AuthRequest auth_request with (client_nonce, client_keyshare)
@@ -1492,7 +1492,7 @@ def AuthClientFinalize(client_identity, client_private_key, server_identity,
 ### 3DH Server Functions {#ake-server}
 
 ~~~
-AuthRespond
+AuthServerRespond
 
 Parameters:
 - Nn, the nonce length.
@@ -1512,8 +1512,8 @@ Input:
 Output:
 - ke2, a KE2 structure.
 
-def AuthRespond(server_identity, server_private_key, client_identity,
-                client_public_key, ke1, credential_response):
+def AuthServerRespond(server_identity, server_private_key, client_identity,
+                      client_public_key, ke1, credential_response):
   server_nonce = random(Nn)
   (server_private_keyshare, server_keyshare) = GenerateAuthKeyPair()
   Create inner_ke2 ike2 with (ke1.credential_response, server_nonce, server_keyshare)


### PR DESCRIPTION
This finishes the last portion of #352, in which I wanted to reorder the subsections slightly in the AKE portion to make things more clear.

Before this change, we had the following ordering of subsections in AKE:

"Online Authenticated Key Exchange" main section with protocol description at a high level 
- "Client Authentication Functions" subsection
- "Server Authentication Functions" subsection
- "Credential Retrieval" subsection
- "AKE Protocol"
  - "AKE Messages" section, this is where KE1, KE2, KE3 are defined
  - "3DH Client Functions" subsection
  - "3DH Server Functions" subsection

So the main problem was that the first two subsections, Client/Server Authentication Functions, were outputting messages that were only defined in the "AKE Messages" subsection, which was much later.

This seems like quite a different structure from the Registration portion, which is currently organized like:

"Client Credential Storage and Key Recovery" main section
"Offline Registration" main section
- "Registration Messages" subsection
- "Registration Functions" subsection

which is a way simpler layout.


--------

So the change I am making here is to:
1) Combine the "Client Authentication Functions" and "Server Authentication Functions" into one subsection, called "AKE Functions", so that it matches up with the layout of registration
2) Put "AKE Messages" as the section immediately following the main protocol description, followed by the new "AKE Functions" subsection
3) Leave the remainder of the subsections as-is in terms of ordering. So the new layout looks like this now:

"Online Authenticated Key Exchange" main section with protocol description at a high level 
- "AKE Messages" subsection
- "AKE Functions" subsection
- "Credential Retrieval" subsection
- "AKE Protocol"
  - "3DH Client Functions" subsection
  - "3DH Server Functions" subsection
  
  Hope this makes sense!
  
  In making this change, there were also some smaller adjustments I made, as well:
  - renamed the 3dh functions from "Start" to "AuthStart", "Response" to "AuthRespond" (it should be at least be a verb), "ClientFinalize" to "AuthClientFinalize", and "ServerFinalize" to "AuthServerFinalize"
  - I also added a definition for ServerFinish, which simply calls AuthServerFinalize, but this was previously a completely undefined function
  - Added text at the beginning of the "AKE Functions" subsection to clarify that the subroutines that we call there are defined in later sections

Btw, a change I was tempted to make, but did not end up making was to combine the "3DH client functions" and "3DH server functions" also into one section. We don't seem to be doing the splitting of client vs. server functions elsewhere anymore (especially after this change), so it is necessary that we do it in the very last section?
