### PR TITLE
fix expired url signature

### DIFF
--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -213,7 +213,7 @@ protocols"
 
   WhatsAppE2E:
     title: Security of End-to-End Encrypted Backups
-    target: https://scontent.whatsapp.net/v/t39.8562-34/241394876_546674233234181_8907137889500301879_n.pdf/WhatsApp_Security_Encrypted_Backups_Whitepaper.pdf?ccb=1-5&_nc_sid=2fbf2a&_nc_ohc=Y3PFzd-3LG4AX9AdA8_&_nc_ht=scontent.whatsapp.net&oh=01_AVwwbFhPNWAn-u9VV4wqetjL2T9rX2pDmXwlk0aus4YrKA&oe=620029BC
+    target: https://www.whatsapp.com/security/WhatsApp_Security_Encrypted_Backups_Whitepaper.pdf
     authors:
       -
         ins: WhatsApp


### PR DESCRIPTION
The url referenced is a signed url that expired (see code below).  I replaced it with a url that  is permanent.  the url does 301 but it 301's to a signed url that is created upon the request
# permanent url
```bash
 curl -L -vvv "https://www.whatsapp.com/security/WhatsApp_Security_Encrypted_Backups_Whitepaper.pdf"
*   Trying 157.240.22.53:443...
* TCP_NODELAY set
* Connected to www.whatsapp.com (157.240.22.53) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/certs/ca-certificates.crt
  CApath: /etc/ssl/certs
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_CHACHA20_POLY1305_SHA256
* ALPN, server accepted to use h2
* Server certificate:
*  subject: C=US; ST=California; L=Menlo Park; O=Facebook, Inc.; CN=*.whatsapp.net
*  start date: Mar  5 00:00:00 2022 GMT
*  expire date: Jun  3 23:59:59 2022 GMT
*  subjectAltName: host "www.whatsapp.com" matched cert's "*.whatsapp.com"
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=DigiCert SHA2 High Assurance Server CA
*  SSL certificate verify ok.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x56047695e8c0)
> GET /security/WhatsApp_Security_Encrypted_Backups_Whitepaper.pdf HTTP/2
> Host: www.whatsapp.com
> user-agent: curl/7.68.0
> accept: */*
>
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* Connection state changed (MAX_CONCURRENT_STREAMS == 100)!
< HTTP/2 301
< vary: Accept-Encoding
< set-cookie: wa_lang_pref=en; expires=Thu, 02-Jun-2022 02:23:23 GMT; Max-Age=604800; path=/; domain=.whatsapp.com; secure
< set-cookie: wa_ul=46238afc-a1ee-4d23-b814-edb29c4829b4; expires=Sat, 25-May-2024 02:23:23 GMT; Max-Age=63072000; path=/; domain=.www.whatsapp.com; secure; httponly
< location: https://scontent-sjc3-1.xx.fbcdn.net/v/t39.8562-6/241394876_546674233234181_8907137889500301879_n.pdf?_nc_cat=108&ccb=1-7&_nc_sid=ad8a9d&_nc_ohc=Ftgo5r_SdYEAX8FhK4j&_nc_ht=scontent-sjc3-1.xx&oh=00_AT_tn4hSzMPsNjvtYVrlGKQ_hphdCa8xhRy8nRyZtEHzRw&oe=629490E6
< document-policy: force-load-at-top
< cross-origin-resource-policy: rollout
< pragma: no-cache
< cache-control: private, no-cache, no-store, must-revalidate
< expires: Sat, 01 Jan 2000 00:00:00 GMT
< x-content-type-options: nosniff
< x-xss-protection: 0
< x-frame-options: DENY
< strict-transport-security: max-age=31536000; preload; includeSubDomains
< content-type: text/html; charset="utf-8"
< x-fb-debug: KCaq4jT8xN+paygEbZKm7/8PLgcM+XoUAp1gSmWwQ+ZkWWZqg4gruqInRPge2QKyzQtl8aniYM/ePo9HqsFWLw==
< content-length: 0
< priority: u=3,i
< x-fb-trip-id: 1679558926
< date: Thu, 26 May 2022 02:23:23 GMT
< alt-svc: h3=":443"; ma=86400,h3-29=":443"; ma=86400
<
* Connection #0 to host www.whatsapp.com left intact
* Issue another request to this URL: 'https://scontent-sjc3-1.xx.fbcdn.net/v/t39.8562-6/241394876_546674233234181_8907137889500301879_n.pdf?_nc_cat=108&ccb=1-7&_nc_sid=ad8a9d&_nc_ohc=Ftgo5r_SdYEAX8FhK4j&_nc_ht=scontent-sjc3-1.xx&oh=00_AT_tn4hSzMPsNjvtYVrlGKQ_hphdCa8xhRy8nRyZtEHzRw&oe=629490E6'
*   Trying 157.240.22.25:443...
* TCP_NODELAY set
* Connected to scontent-sjc3-1.xx.fbcdn.net (157.240.22.25) port 443 (#1)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/certs/ca-certificates.crt
  CApath: /etc/ssl/certs
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_CHACHA20_POLY1305_SHA256
* ALPN, server accepted to use h2
* Server certificate:
*  subject: C=US; ST=California; L=Menlo Park; O=Facebook, Inc.; CN=*.facebook.com
*  start date: Mar  5 00:00:00 2022 GMT
*  expire date: Jun  3 23:59:59 2022 GMT
*  subjectAltName: host "scontent-sjc3-1.xx.fbcdn.net" matched cert's "*.xx.fbcdn.net"
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=DigiCert SHA2 High Assurance Server CA
*  SSL certificate verify ok.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x56047695e8c0)
> GET /v/t39.8562-6/241394876_546674233234181_8907137889500301879_n.pdf?_nc_cat=108&ccb=1-7&_nc_sid=ad8a9d&_nc_ohc=Ftgo5r_SdYEAX8FhK4j&_nc_ht=scontent-sjc3-1.xx&oh=00_AT_tn4hSzMPsNjvtYVrlGKQ_hphdCa8xhRy8nRyZtEHzRw&oe=629490E6 HTTP/2
> Host: scontent-sjc3-1.xx.fbcdn.net
> user-agent: curl/7.68.0
> accept: */*
>
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* Connection state changed (MAX_CONCURRENT_STREAMS == 100)!
< HTTP/2 200
< last-modified: Wed, 08 Sep 2021 19:29:18 GMT
< accept-ranges: bytes
< content-type: application/pdf
< x-haystack-needlechecksum: 1093967180
< x-needle-checksum: 2876820207
< content-digest: adler32=2876820207
< timing-allow-origin: *
< cross-origin-resource-policy: cross-origin
< cache-control: max-age=1209600, no-transform
< content-length: 610383
< x-fb-trip-id: 664085054
< date: Thu, 26 May 2022 02:23:23 GMT
< alt-svc: h3=":443"; ma=86400,h3-29=":443"; ma=86400
<
Warning: Binary output can mess up your terminal. Use "--output -" to tell
Warning: curl to output it to your terminal anyway, or consider "--output
Warning: <FILE>" to save to a file.
* Failed writing body (0 != 1492)
* stopped the pause stream!
* Connection #1 to host scontent-sjc3-1.xx.fbcdn.net left intact
```
# expired url

```bash
curl -L -vvv "https://scontent.whatsapp.net/v/t39.8562-34/241394876_546674233234181_8907137889500301879_n.pdf/WhatsApp_Security_Encrypted_Backups_Whitepaper.pdf?ccb=1-5&_nc_sid=2fbf2a&_nc_ohc=Y3PFzd-3LG4AX9AdA8_&_nc_ht=scontent.whatsapp.net&oh=01_AVwwbFhPNWAn-u9VV4wqetjL2T9rX2pDmXwlk0aus4YrKA&oe=620029BC"
*   Trying 157.240.22.53:443...
* TCP_NODELAY set
* Connected to scontent.whatsapp.net (157.240.22.53) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/certs/ca-certificates.crt
  CApath: /etc/ssl/certs
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_CHACHA20_POLY1305_SHA256
* ALPN, server accepted to use h2
* Server certificate:
*  subject: C=US; ST=California; L=Menlo Park; O=Facebook, Inc.; CN=*.whatsapp.net
*  start date: Mar  5 00:00:00 2022 GMT
*  expire date: Jun  3 23:59:59 2022 GMT
*  subjectAltName: host "scontent.whatsapp.net" matched cert's "*.whatsapp.net"
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=DigiCert SHA2 High Assurance Server CA
*  SSL certificate verify ok.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x55aa806c88c0)
> GET /v/t39.8562-34/241394876_546674233234181_8907137889500301879_n.pdf/WhatsApp_Security_Encrypted_Backups_Whitepaper.pdf?ccb=1-5&_nc_sid=2fbf2a&_nc_ohc=Y3PFzd-3LG4AX9AdA8_&_nc_ht=scontent.whatsapp.net&oh=01_AVwwbFhPNWAn-u9VV4wqetjL2T9rX2pDmXwlk0aus4YrKA&oe=620029BC HTTP/2
> Host: scontent.whatsapp.net
> user-agent: curl/7.68.0
> accept: */*
>
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* Connection state changed (MAX_CONCURRENT_STREAMS == 100)!
< HTTP/2 403
< access-control-allow-origin: *
< proxy-status: http_request_error; e_clientaddr="AcIcw49dU5SXoSgm2qhCY9JOdwmk-g7c4eL0YvmM8gcKjeRWt7VTcDw0p4fVzJHBz7BNUQkP4PCN6wgU"; e_fb_vipaddr="AcJD9xXeefcgDQNsMeLor06rEBtY3O4Qu4Uy2BEpNq-YQtMM3MM_rIFmYmmf_RM9T73Yo-GGZA"; e_fb_builduser="AcJHKIOsCvuc8JAokZdFbf1WJK0zju-kg0oqibai1hjBjNwvnJviyTFnV7gkAUH63L8"; e_fb_binaryversion="AcJeNSI_2YNqiSMB0sQx46y2BsFAPGHJPVj1aqitKyii94gZGThfoa2JLee-QHcZ7ZSBof14-3P603u-kFsFSgBAxdOZvmTCELg"; e_proxy="AcJ5u76IEcc742pAwBj8e53fZT3EECWrxuU4RZJKEgZmcH6JJqJ-qQjVHaC6pwKY4cNzgVM7NKYXS_rH"
< content-type: text/plain
< content-length: 21
< server: proxygen-bolt
< x-fb-trip-id: 1679558926
< date: Thu, 26 May 2022 02:08:31 GMT
< alt-svc: h3=":443"; ma=86400,h3-29=":443"; ma=86400
<
* Connection #0 to host scontent.whatsapp.net left intact
```