### PR TITLE
Removing reference to internal mode in configuration strings

### DIFF
--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -1673,8 +1673,8 @@ parameters that are needed to prevent cross-protocol or downgrade attacks.
 
 Absent an application-specific profile, the following configurations are RECOMMENDED:
 
-- OPRF(ristretto255, SHA-512), HKDF-SHA-512, HMAC-SHA-512, SHA-512, Scrypt(32768,8,1), internal, ristretto255
-- OPRF(P-256, SHA-256), HKDF-SHA-256, HMAC-SHA-256, SHA-256, Scrypt(32768,8,1), internal, P-256
+- OPRF(ristretto255, SHA-512), HKDF-SHA-512, HMAC-SHA-512, SHA-512, Scrypt(32768,8,1), ristretto255
+- OPRF(P-256, SHA-256), HKDF-SHA-256, HMAC-SHA-256, SHA-256, Scrypt(32768,8,1), P-256
 
 Future configurations may specify different combinations of dependent algorithms,
 with the following considerations:


### PR DESCRIPTION
Closes #370.

ccing @stef for pointing out the change and @bytemare as an FYI for the original PR that introduced the string

As stated in the issue, I believe this "internal" string should be omitted. It was introduced in https://github.com/cfrg/draft-irtf-cfrg-opaque/commit/950f2f0586dd03a2b3ffab11008c21a4d0d3f12b back when there was an "external" and "internal" mode for the envelope configuration portion of the protocol. Now that we no longer have those, we should have removed this internal configuration reference, but failed to.

