### PR TITLE
Rename "ephemeral key share" to "ephemeral public key"

### DIFF
--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -1673,8 +1673,8 @@ parameters that are needed to prevent cross-protocol or downgrade attacks.
 
 Absent an application-specific profile, the following configurations are RECOMMENDED:
 
-- OPRF(ristretto255, SHA-512), HKDF-SHA-512, HMAC-SHA-512, SHA-512, Scrypt(32768,8,1), internal, ristretto255
-- OPRF(P-256, SHA-256), HKDF-SHA-256, HMAC-SHA-256, SHA-256, Scrypt(32768,8,1), internal, P-256
+- OPRF(ristretto255, SHA-512), HKDF-SHA-512, HMAC-SHA-512, SHA-512, Scrypt(32768,8,1), ristretto255
+- OPRF(P-256, SHA-256), HKDF-SHA-256, HMAC-SHA-256, SHA-256, Scrypt(32768,8,1), P-256
 
 Future configurations may specify different combinations of dependent algorithms,
 with the following considerations:

--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -1000,7 +1000,7 @@ struct {
 
 client_nonce: A fresh randomly generated nonce of length `Nn`.
 
-client_keyshare: A serialized client ephemeral key share of fixed size `Npk`.
+client_keyshare: A serialized client ephemeral public key of fixed size `Npk`.
 
 ~~~
 struct {
@@ -1023,7 +1023,7 @@ struct {
 
 server_nonce: A fresh randomly generated nonce of length `Nn`.
 
-server_keyshare: Server ephemeral key share of fixed size `Npk`, where `Npk`
+server_keyshare: A server ephemeral public key of fixed size `Npk`, where `Npk`
 depends on the corresponding prime order group.
 
 server_mac: An authentication tag computed over the handshake transcript
@@ -2252,7 +2252,7 @@ computed as in OPAQUE-3DH.
 
 The key schedule would also change. Specifically, the key schedule `preamble` value would
 use a different constant prefix -- "SIGMA-I" instead of "3DH" -- and the `IKM` computation
-would use only the ephemeral key shares exchanged between client and server.
+would use only the ephemeral public keys exchanged between client and server.
 
 # Test Vectors {#test-vectors}
 


### PR DESCRIPTION
Closes #371.

See the discussion in #371 for more context. Note that this only changes the prose describing the variable names, and not the variable names themselves.

cc'ing @stef for feedback