### PR TITLE
Fix h2c submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "poc/h2c"]
-	path = poc/h2c
-	url = git@github.com:cfrg/draft-irtf-cfrg-hash-to-curve.git
-	branch = main
 [submodule "poc/voprf"]
 	path = poc/voprf
 	url = git@github.com:cfrg/draft-irtf-cfrg-voprf.git

--- a/poc/Makefile
+++ b/poc/Makefile
@@ -3,7 +3,7 @@ PYFILES := $(addprefix sagelib/, $(addsuffix .py,$(SAGEFILES)))
 .PRECIOUS: $(PYFILES)
 
 .PHONY: pyfiles
-pyfiles: sagelib/__init__.py $(PYFILES)
+pyfiles: setup sagelib/__init__.py $(PYFILES)
 
 sagelib/__init__.py:
 	mkdir -p sagelib
@@ -15,11 +15,12 @@ sagelib/%.py: %.sage
 	@mv $<.py $@
 
 setup:
-	cp h2c/poc/hash_to_field.py .
-	cp h2c/poc/*.sage .
+	cp voprf/poc/h2c/poc/hash_to_field.py .
+	cp voprf/poc/h2c/poc/*.sage .
 	cp voprf/poc/*.sage .
 
 test: pyfiles
+	@mkdir -p vectors
 	sage test_opaque_ake.sage
 
 vectors: pyfiles

--- a/poc/opaque_ake.sage
+++ b/poc/opaque_ake.sage
@@ -61,7 +61,7 @@ class OPAQUE3DH(KeyExchange):
         return {
             "Name": "3DH",
             "Group": self.config.group.name,
-            "OPRF": to_hex(I2OSP(self.config.oprf_suite.identifier, 2)),
+            "OPRF": self.config.oprf_suite.identifier,
             "KDF": self.config.kdf.name,
             "MAC": self.config.mac.name,
             "Hash": self.config.hash().name.upper(),


### PR DESCRIPTION
Changes:
 - Removes duplicated submodule for h2c. Better to use the one inside the voprf module.
 - ~Exports more values to make the Fake case reproducible. No changes on test vectors, just more verbose info for the `Fake=True` cases.~