### PR TITLE
Add Hugo's suggestion about Thresholding

### DIFF
--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -1910,7 +1910,7 @@ implementation considerations.
   protocol is secure. The choice of such inputs is up to the application.
 - {{JKX18}} comments on a defense against offline
   dictionary attacks upon server compromise or honest-but-curious servers.
-  The authors suggest implementing the OPRF phase as a Threshold OPRF {{TOPPSS}},
+  The authors suggest implementing the OPRF phase as a threshold OPRF {{TOPPSS}},
   effectively forcing an attacker to act online or to control at least t key
   shares (among the total n), where t is the threshold number of shares necessary
   to recombine the secret OPRF key, and only then be able to run an offline dictionary

--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -1912,9 +1912,12 @@ implementation considerations.
   dictionary attacks upon server compromise or honest-but-curious servers.
   The authors suggest implementing the OPRF phase as a Threshold OPRF {{TOPPSS}},
   effectively forcing an attacker to act online or to control at least t key
-  shares, where t is the threshold number of shares necessary to recombine
-  the secret OPRF key, and only then be able to run an offline dictionary attack.
-  This implementation only affects the server and change nothing for the client.
+  shares (among the total n), where t is the threshold number of shares necessary
+  to recombine the secret OPRF key, and only then be able to run an offline dictionary
+  attack. This implementation only affects the server and change nothing for the client.
+  Furthermore, if the Threshold OPRF servers holding these keys are separate from
+  the authentication server, then recovering all n shares would still not suffice
+  to run an offline dictionnary attack without access to the client record database.
   However, this mechanism is out of scope for this document.
 
 The following list enumerates notable differences and refinements from the original

--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -1914,7 +1914,7 @@ implementation considerations.
   effectively forcing an attacker to act online or to control at least t key
   shares (among the total n), where t is the threshold number of shares necessary
   to recombine the secret OPRF key, and only then be able to run an offline dictionary
-  attack. This implementation only affects the server and change nothing for the client.
+  attack. This implementation only affects the server and changes nothing for the client.
   Furthermore, if the Threshold OPRF servers holding these keys are separate from
   the authentication server, then recovering all n shares would still not suffice
   to run an offline dictionnary attack without access to the client record database.

--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -1908,14 +1908,15 @@ implementation considerations.
   of the derivation of OPRF keys via a single PRF. As long as the derivation
   of different OPRF keys from a single OPRF has different PRF inputs, the
   protocol is secure. The choice of such inputs is up to the application.
-- {{JKX18}} comments on a strong defense against essentially the only
+- {{JKX18}} comments on a very strong defense against essentially the only
   inherent remaining weakness of a "strong aPAKE", namely, offline
   dictionary attacks upon server compromise or honest-but-curious servers.
   The authors suggest implementing the OPRF phase as a Threshold OPRF {{TOPPSS}},
   effectively forcing an attacker to act online or to control at least t key
   shares, where t is the threshold number of shares necessary to recombine
-  the secret OPRF key and run an offline dictionary attack. This implementation only affects the server and changes
-  nothing for the client. However, this mechanism is out of scope for this document.
+  the secret OPRF key, and only then be able to run an offline dictionary attack.
+  This implementation only affects the server and change nothing for the client.
+  However, this mechanism is out of scope for this document.
 
 The following list enumerates notable differences and refinements from the original
 cryptographic design in {{JKX18}} and the corresponding CFRG document

--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -1908,8 +1908,7 @@ implementation considerations.
   of the derivation of OPRF keys via a single PRF. As long as the derivation
   of different OPRF keys from a single OPRF has different PRF inputs, the
   protocol is secure. The choice of such inputs is up to the application.
-- {{JKX18}} comments on a very strong defense against essentially the only
-  inherent remaining weakness of a "strong aPAKE", namely, offline
+- {{JKX18}} comments on a defense against offline
   dictionary attacks upon server compromise or honest-but-curious servers.
   The authors suggest implementing the OPRF phase as a Threshold OPRF {{TOPPSS}},
   effectively forcing an attacker to act online or to control at least t key

--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -1915,7 +1915,7 @@ implementation considerations.
   shares (among the total n), where t is the threshold number of shares necessary
   to recombine the secret OPRF key, and only then be able to run an offline dictionary
   attack. This implementation only affects the server and changes nothing for the client.
-  Furthermore, if the Threshold OPRF servers holding these keys are separate from
+  Furthermore, if the threshold OPRF servers holding these keys are separate from
   the authentication server, then recovering all n shares would still not suffice
   to run an offline dictionnary attack without access to the client record database.
   However, this mechanism is out of scope for this document.


### PR DESCRIPTION
In #397 , @hugokraw suggested

> I suggest the following edit  (marked in italics)
>
> The authors suggest implementing the OPRF phase as a Threshold OPRF
> {{TOPPSS}}, effectively forcing an attacker to act online or to control at
> least t key shares, where t is the threshold number of shares necessary to
> recombine the secret OPRF key*, and only then be able to* run an offline
> dictionary attack.

This PR adds this.

Moreover, he suggested

> You may or may not comment also in the following point:
If the OPRF servers are separate from the authentication server then
finding all n shares still does not help since you cannot run the dictionary
attack without the server's database.

@hugokraw, do you mean _n_ like in "all shares that have been created" or "a threshold number of shares"?