### PR TITLE
POC Makefile: Don't re-setup every time

### DIFF
--- a/poc/Makefile
+++ b/poc/Makefile
@@ -3,7 +3,7 @@ PYFILES := $(addprefix sagelib/, $(addsuffix .py,$(SAGEFILES)))
 .PRECIOUS: $(PYFILES)
 
 .PHONY: pyfiles
-pyfiles: setup sagelib/__init__.py $(PYFILES)
+pyfiles: sagelib/__init__.py $(PYFILES)
 
 sagelib/__init__.py:
 	mkdir -p sagelib


### PR DESCRIPTION
Having `setup` as a prerequisite of `pyfiles` (which itself is a prerequisite of `test` and `vectors`) means everytime you do `make test`, `setup` is run too. This means the files from submodules are copied and then have to be re-parsed by sage which really slows everything down.

Any future additions to the makefile will also likely have `pyfiles` as a prerequisite so have this problem too. This is the case for my fork and is causing problems.

The downside is that `make setup` must be run the first time so that the files are copied, but this was the case before the commit on 14th March anyway.