### PR TITLE
replace "password file" with "registration record"

### DIFF
--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -1938,7 +1938,7 @@ implementation considerations.
   applications of the protocol. This change was made to allow different
   applications to use OPAQUE without the risk of cross-protocol attacks.
 - Servers use a separate identifier for computing OPRF evaluations and
-  indexing into the password file storage, called the credential_identifier.
+  indexing into the registration record storage, called the credential_identifier.
   This allows clients to change their application-layer identity
   (client_identity) without inducing server-side changes, e.g., by changing
   an email address associated with a given account. This mechanism is part


### PR DESCRIPTION
The term "password file" is not used anywhere else in the spec. Usually it's referred to as `record` and the type is `RegistrationRecord`. To avoid confusion I suggest to change it to `registration record` in this particular place.