### PR TITLE
Updating klewi's affiliation

### DIFF
--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -24,7 +24,7 @@ author:
  -
     ins: K. Lewi
     name: Kevin Lewi
-    organization: Novi Research
+    organization: Meta 
     email: lewi.kevin.k@gmail.com
  -
     ins: C. A. Wood

--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -24,7 +24,7 @@ author:
  -
     ins: K. Lewi
     name: Kevin Lewi
-    organization: Meta 
+    organization: Meta
     email: lewi.kevin.k@gmail.com
  -
     ins: C. A. Wood


### PR DESCRIPTION
Novi Research -> Meta

(They're the same thing, but Novi Research doesn't exist anymore)