### PR TITLE
Fixing minor typos: extraneous mac computation, ke2.server_mac

### DIFF
--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -1656,7 +1656,7 @@ def AuthClientFinalize(cleartext_credentials, client_private_key, ke2):
                       ke2.auth_response.server_public_keyshare)
   Km2, Km3, session_key = DeriveKeys(ikm, preamble)
   expected_server_mac = MAC(Km2, Hash(preamble))
-  if !ct_equal(ke2.server_mac, expected_server_mac),
+  if !ct_equal(ke2.auth_response.server_mac, expected_server_mac),
     raise ServerAuthenticationError
   client_mac = MAC(Km3, Hash(concat(preamble, expected_server_mac)))
   Create KE3 ke3 with client_mac
@@ -1704,7 +1704,6 @@ def AuthServerRespond(cleartext_credentials, server_private_key, client_public_k
 
   Km2, Km3, session_key = DeriveKeys(ikm, preamble)
   server_mac = MAC(Km2, Hash(preamble))
-  expected_client_mac = MAC(Km3, Hash(concat(preamble, server_mac)))
 
   state.expected_client_mac = MAC(Km3, Hash(concat(preamble, server_mac)))
   state.session_key = session_key


### PR DESCRIPTION
From [#418:](https://github.com/cfrg/draft-irtf-cfrg-opaque/issues/418#issuecomment-1737188161):

Fixes the following two issues:
- In function AuthServerRespond the value expected_client_mac is computed twice (I think the first line can be dropped)
- In function AuthClientFinalize the value ke2.server_mac is used that doesn't exist, it should be ke2.auth_response.server_mac