### PR TITLE
Fixing FinalizeRegistrationRequest diagram API

### DIFF
--- a/draft-irtf-cfrg-opaque.md
+++ b/draft-irtf-cfrg-opaque.md
@@ -784,7 +784,9 @@ The registration protocol then runs as shown below:
                         response
               <-------------------------
 
- (record, export_key) = FinalizeRegistrationRequest(response,
+ (record, export_key) = FinalizeRegistrationRequest(password,
+                                                    blind,
+                                                    response,
                                                     server_identity,
                                                     client_identity)
 


### PR DESCRIPTION
There was a mismatch between the definition of FinalizeRegistrationRequest, and its representation in the protocol diagram. This adds the missing parameters (password, blind) to the diagram.